### PR TITLE
Adds the missing parameter to `orbdir`

### DIFF
--- a/liborbital/orbdir.ks
+++ b/liborbital/orbdir.ks
@@ -1,6 +1,10 @@
 function orbdir {
-//returns direction with vector=AN vector, up=normal
-  local normvec to vcrs(body:position-orbit:position,velocity:orbit).
-  local anvec to vcrs(normvec,V(0,1,0)).
-  return lookdirup(anvec,normvec).
+// Returns direction with vector = AN vector, up = normal
+// Parameters:
+// * refNRM - normal to the orbit wrt which the the AN is taken.
+//   Default: V(0,1,0) - equatorial prograde orbit
+  parameter refNRM is V(0,1,0). 
+  local normvec is vcrs(body:position-orbit:position,velocity:orbit).
+  local anvec is vcrs(normvec, refNRM).
+  return lookdirup(anvec, normvec).
 }


### PR DESCRIPTION
`refNRM` is the normal vector to the "reference" orbit